### PR TITLE
Update build-docker.sh

### DIFF
--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -9,6 +9,8 @@ mvn clean install -DskipTests
 
 cp $BASEDIR/../target/*.war "$BASEDIR/ast-web-viewer.war"
 
+cd "$BASEDIR"
+
 sudo docker build -t checkstyle/ast-web-viewer .
 
 echo "Done. To execute the application, run:"


### PR DESCRIPTION
when run build-docker.sh, output: 
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /root/checkstyle-ast-web-viewer/Dockerfile: no such file or directory
